### PR TITLE
Add tests to cs checks and disallow long array syntax

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0"?>
 <ruleset name="BaconPdf">
     <file>./src</file>
+    <file>./test</file>
+    
     <rule ref="PSR2"/>
+    <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
+    
+    <rule ref="Generic.Files.LineLength">
+        <exclude-pattern>test/*</exclude-pattern>
+    </rule>
 </ruleset>
 


### PR DESCRIPTION
Added CS rule to disallow `array()` in favor of `[]`
Added tests to CS checks
Disabled line length rule for tests
